### PR TITLE
fix: align Android build tooling versions

### DIFF
--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- fix Android build by using stable Gradle and plugin versions

## Testing
- `flutter build apk -v` *(fails: command not found)*
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be7ce2d458832cbbc009bf2324dcd6