### PR TITLE
Handle AuthException on login

### DIFF
--- a/mobile/lib/pages/uniclub_page.dart
+++ b/mobile/lib/pages/uniclub_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import '../supabase_client.dart';
 
 class UniClubPage extends StatefulWidget {
@@ -14,11 +15,18 @@ class _UniClubPageState extends State<UniClubPage> {
   String? message;
 
   Future<void> _login() async {
-    final res = await supabase.auth.signInWithPassword(
-      email: _email.text,
-      password: _password.text,
-    );
-    setState(() => message = res.session != null ? 'Logged in!' : res.error?.message);
+    try {
+      final res = await supabase.auth.signInWithPassword(
+        email: _email.text,
+        password: _password.text,
+      );
+      setState(() =>
+          message = res.session != null ? 'Logged in!' : 'No session returned');
+    } on AuthException catch (error) {
+      setState(() => message = error.message);
+    } catch (_) {
+      setState(() => message = 'Unexpected error');
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- handle auth sign-in errors using AuthException instead of removed AuthResponse.error

## Testing
- `dart format mobile/lib/pages/uniclub_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb9331f44832cb8f086b6fbad9d5f